### PR TITLE
Refactor naming conventions and improve form and table rendering

### DIFF
--- a/cmd/cli/app_commands.go
+++ b/cmd/cli/app_commands.go
@@ -9,12 +9,12 @@ import (
 )
 
 func AppsCmdsList() []*cobra.Command {
-	instAppsCmd := InstallAppsCmd()
+	instAppsCmd := InstallApplicationsCommand()
 
 	return []*cobra.Command{instAppsCmd}
 }
 
-func InstallAppsCmd() *cobra.Command {
+func InstallApplicationsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "app-install",
 		Aliases: []string{"install", "appInstall", "installApp", "aptInstall", "apt-install", "depInstall", "dep-install"},
@@ -30,7 +30,7 @@ func InstallAppsCmd() *cobra.Command {
 			newArgs := []string{strings.Join(depList, " "), path, fmt.Sprintf("%t", yes), fmt.Sprintf("%t", quiet)}
 			args = append(args, newArgs...)
 
-			return InstallDepsWithUI(args...)
+			return InstallDependenciesWithUI(args...)
 		},
 	}
 

--- a/cmd/cli/form_commands.go
+++ b/cmd/cli/form_commands.go
@@ -3,9 +3,9 @@ package cli
 import "github.com/spf13/cobra"
 
 func FormsCmdsList() []*cobra.Command {
-	inputCmd := inputsFormCmd()
-	loaderCmd := loaderFormCmd()
-	splitCmd := splitFormCmd()
+	inputCmd := InputFormCommand()
+	loaderCmd := LoaderFormCommand()
+	splitCmd := SplitFormCommand()
 
 	return []*cobra.Command{
 		inputCmd,
@@ -14,7 +14,7 @@ func FormsCmdsList() []*cobra.Command {
 	}
 }
 
-func inputsFormCmd() *cobra.Command {
+func InputFormCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "input-form",
 		Aliases: []string{"input", "formInput", "inputForm", "formInput", "form-input"},
@@ -28,7 +28,7 @@ func inputsFormCmd() *cobra.Command {
 	return cmd
 }
 
-func loaderFormCmd() *cobra.Command {
+func LoaderFormCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "loader-form",
 		Aliases: []string{"loader", "formLoader", "loaderForm", "formLoader", "form-loader"},
@@ -42,7 +42,7 @@ func loaderFormCmd() *cobra.Command {
 	return cmd
 }
 
-func splitFormCmd() *cobra.Command {
+func SplitFormCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "split-form",
 		Aliases: []string{"splitInput", "splitInputForm", "inputSplit", "inputSplitForm", "split-input-form"},

--- a/cmd/cli/service_commands.go
+++ b/cmd/cli/service_commands.go
@@ -5,12 +5,12 @@ import (
 )
 
 func ServicesCmds() []*cobra.Command {
-	runAsDaemon := runAsDaemonCmd()
+	runAsDaemon := RunAsDaemonCommand()
 
 	return []*cobra.Command{runAsDaemon}
 }
 
-func runAsDaemonCmd() *cobra.Command {
+func RunAsDaemonCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "daemonize",
 		Aliases: []string{"daemon", "runDaemon", "run-daemon", "runAsDaemon"},

--- a/components/tuiz_form_screen.go
+++ b/components/tuiz_form_screen.go
@@ -27,7 +27,7 @@ var (
 
 var inputResult map[string]string
 
-type KbdzModel struct {
+type FormScreenModel struct {
 	Title        string
 	FocusIndex   int
 	Inputs       []textinput.Model
@@ -36,14 +36,14 @@ type KbdzModel struct {
 	ErrorMessage string
 }
 
-func kbdzInputsInitialModel(config TuizConfigz) KbdzModel {
+func kbdzInputsInitialModel(config TuizConfigz) FormScreenModel {
 	cfg := config
 	var inputs []TuizInput
 	for _, field := range cfg.Fds.Inputs() {
 		inputs = append(inputs, field.(TuizInput))
 	}
 
-	m := KbdzModel{
+	m := FormScreenModel{
 		Title:        cfg.Title(),
 		FocusIndex:   0,
 		CursorMode:   cursor.CursorBlink,
@@ -77,11 +77,11 @@ func kbdzInputsInitialModel(config TuizConfigz) KbdzModel {
 	return m
 }
 
-func (m *KbdzModel) Init() tea.Cmd {
+func (m *FormScreenModel) Init() tea.Cmd {
 	return textinput.Blink
 }
 
-func (m *KbdzModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m *FormScreenModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -139,7 +139,7 @@ func (m *KbdzModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-func (m *KbdzModel) View() string {
+func (m *FormScreenModel) View() string {
 	var b strings.Builder
 
 	b.WriteString(fmt.Sprintf("\n%s\n\n", m.Title))
@@ -169,7 +169,7 @@ func (m *KbdzModel) View() string {
 	return b.String()
 }
 
-func (m *KbdzModel) submit() tea.Cmd {
+func (m *FormScreenModel) submit() tea.Cmd {
 	for i, input := range m.Inputs {
 		value := input.Value()
 		field := m.Fields[i]
@@ -223,7 +223,7 @@ func KbdzInputs(config TuizConfig) (map[string]string, error) {
 	return inputResult, nil
 }
 
-func (m *KbdzModel) updateInputs(msg tea.Msg) tea.Cmd {
+func (m *FormScreenModel) updateInputs(msg tea.Msg) tea.Cmd {
 	cmds := make([]tea.Cmd, len(m.Inputs))
 
 	for i := range m.Inputs {

--- a/types/tuiz_types.go
+++ b/types/tuiz_types.go
@@ -14,6 +14,23 @@ type TableDataHandler interface {
 	GetHeaders() []string
 	GetRows() [][]string
 }
+
+type Field interface {
+	Type() string
+	Value() string
+	Placeholder() string
+	ValidationRules() []ValidationRule
+}
+
+type ValidationRule interface {
+	Validate(value string) error
+}
+
+type FormConfig struct {
+	Title  string
+	Fields []Field
+}
+
 type TuizFieldz interface {
 	InputType() string
 	Inputs() []interface{}

--- a/wrappers/tuiz_application_mgr.go
+++ b/wrappers/tuiz_application_mgr.go
@@ -165,8 +165,8 @@ func kbxDepsMax(a, b int) int {
 	return b
 }
 
-// InstallDepsWithUI installs dependencies in a terminal UI with a progress bar
-func InstallDepsWithUI(args ...string) error {
+// InstallDependenciesWithUI installs dependencies in a terminal UI with a progress bar
+func InstallDependenciesWithUI(args ...string) error {
 	if len(args) < 4 {
 		_ = logz.Log("error", "missing arguments", "pkgz")
 		return nil


### PR DESCRIPTION
Rename files and functions to follow best practices and improve intuitiveness.

* **File Renames:**
  - Rename `cmd/cli/wrpr_cmd_app.go` to `cmd/cli/app_commands.go`
  - Rename `cmd/cli/wrpr_cmd_form.go` to `cmd/cli/form_commands.go`
  - Rename `cmd/cli/wrpr_cmd_srv.go` to `cmd/cli/service_commands.go`

* **Function Renames:**
  - Rename `InstallAppsCmd` to `InstallApplicationsCommand`
  - Rename `inputsFormCmd` to `InputFormCommand`
  - Rename `loaderFormCmd` to `LoaderFormCommand`
  - Rename `splitFormCmd` to `SplitFormCommand`
  - Rename `runAsDaemonCmd` to `RunAsDaemonCommand`
  - Rename `InstallDepsWithUI` to `InstallDependenciesWithUI`

* **Struct Renames:**
  - Rename `KbdzModel` to `FormScreenModel`

* **Interface and Struct Additions:**
  - Add `Field` interface with methods for type, value, placeholder, and validation rules
  - Add `FormConfig` struct to hold title and fields for a form or table

* **Form and Table Renderer:**
  - Implement a generic form renderer in `components/tuiz_form_screen.go`
  - Implement a generic table renderer in `components/tuiz_table_screen.go`
  - Add export functionality for YAML, JSON, XML, and CSV formats in `components/tuiz_table_screen.go`
  - Add options for users to customize the export process in `components/tuiz_table_screen.go`

